### PR TITLE
Optimitize EnKF code

### DIFF
--- a/enkf.py
+++ b/enkf.py
@@ -67,7 +67,7 @@ class enkf_1ob():
         self.m, self.N = x_b.shape  # m = number of model variables, N = ensemble size
 
 
-    def compute_x_b_mean_dev(self):
+    def _compute_x_b_mean_dev(self):
         """
         Compute ensemble mean and member deviations
         """
@@ -77,7 +77,7 @@ class enkf_1ob():
             self.x_b_dev = self.x_b - self.x_b_bar[:, np.newaxis]         
     
 
-    def compute_Hx_mean_dev(self):
+    def _compute_Hx_mean_dev(self):
         """
         Compute the mean and deviations of Hx
 
@@ -91,84 +91,49 @@ class enkf_1ob():
             self.Hx_b_dev = self.Hx_b - self.Hx_b_bar
     
 
-    def compute_PbHT(self):
-        """
-        Compute P_b H^T
-
-        Covariance of the estimate of the observation from the ensemble with the background
-
-        Houtekamer and Mitchell (2001) eqn (2)
-        """
-
-        if not hasattr(self, 'PbHT'):
-            self.compute_x_b_mean_dev()
-            self.compute_Hx_mean_dev()
-            dum = np.zeros(self.m)
-            for i in range(self.N):
-                dum = dum + (self.x_b_dev[:, i] * (self.Hx_b[i] - self.Hx_b_bar))
-            self.PbHT = dum / (self.N - 1)
-
-            # Apply localization
-            if self.local is not None:
-                self.PbHT = self.PbHT * self.local
-    
-
-    def compute_HPbHT(self):
-        """
-        Compute H P_b H^T
-
-        Variance of the estimate of the observation from the ensemble
-
-        Houtekamer and Mitchell (2001) eqn (3)
-        """
-  
-        if not hasattr(self, 'HPbHT'):
-            self.compute_Hx_mean_dev()
-            self.HPbHT = np.sum((self.Hx_b - self.Hx_b_bar)**2) / (self.N - 1)
-
-
-    def compute_Kalman_gain(self):
+    def _compute_Kalman_gain(self):
         """
         Compute the Kalman gain
 
-        Whitaker and Hamill (2002) eqn (2)
+        Also include calculations for:
+            P_b H^T: Covariance of the estimate of the observation from the ensemble with the background
+            H P_b H^T: Variance of the estimate of the observation from the ensemble
+
+        P_b H^T: Houtekamer and Mitchell (2001) eqn (2)
+        H P_b H^T: Houtekamer and Mitchell (2001) eqn (3)
+        Kalman gain: Whitaker and Hamill (2002) eqn (2)
         """
 
         if not hasattr(self, 'K'):
-            self.compute_PbHT()
-            self.compute_HPbHT()
+            self._compute_x_b_mean_dev()
+            self._compute_Hx_mean_dev()
+ 
+            # Compute PbHT and apply localization
+            self.PbHT = np.inner(self.x_b_dev, self.Hx_b_dev) / (self.N - 1)
+            if self.local is not None:
+                self.PbHT = self.PbHT * self.local
+
+            # Compute HPbHT
+            self.HPbHT = np.sum((self.Hx_b - self.Hx_b_bar)**2) / (self.N - 1)
+
+            # Compute Kalman gain
             self.K = self.PbHT / (self.HPbHT + self.ob_var)
     
-
-    def compute_EnSRF_factor(self):
-        """
-        Compute the square root factor for the EnSRF
-
-        Whitaker and Hamill (2002) eqn (13)
-        """
-
-        if not hasattr(self, 'alpha'):
-            self.compute_HPbHT()
-            self.alpha = 1 / (1 + np.sqrt(self.ob_var / (self.HPbHT + self.ob_var)))
-
 
     def EnSRF(self):
         """
         Compute the analysis mean and deviations using the EnSRF
 
+        EnSRF factor (alpha) comes from Whitaker and Hamill (2002) eqn (13)
+
         Whitaker and Hamill (2002)
         """
 
         if not hasattr(self, 'x_a'):
-            self.compute_x_b_mean_dev()
-            self.compute_Hx_mean_dev()
-            self.compute_Kalman_gain()
-            self.compute_EnSRF_factor()
+            self._compute_Kalman_gain()
+            self.alpha = 1 / (1 + np.sqrt(self.ob_var / (self.HPbHT + self.ob_var)))
             self.x_a_bar = self.x_b_bar + (self.K * (self.y_0 - self.Hx_b_bar))
-            dum = np.zeros(self.x_b.shape)
-            for i in range(self.N):
-                dum[:, i] = self.x_b_dev[:, i] - (self.alpha * self.K * self.Hx_b_dev[i])
-            self.x_a_dev = dum
+            self.x_a_dev = self.x_b_dev - self.alpha * np.outer(self.K, self.Hx_b_dev)
             self.x_a = self.x_a_dev + self.x_a_bar[:, np.newaxis]
 
 


### PR DESCRIPTION
Attempt to optimize the EnKF program without adding any new packages. Changes include:
- Removing all loops by using `np.inner` and `np.outer`
- Consolidating some methods to reduce the number of `hasattr` calls

In addition to the changes above, some minor cosmetic changes were made, such as adding a `_` to the beginning of some method names.

Using the test case from [direct_ceilometer_DA](https://github.com/ShawnMurdzek-NOAA/direct_ceilometer_DA/tree/main), the updated code is ~3% faster.

Further optimization will likely require additional packages, such as numba's JIT. For simplicity, this route was not pursued here.

### Tests
- Confirmed that the EnKF output (i.e., the analysis state) from the updated code for a simple test case is close enough (e.g., using `np.isclose`) to the EnKF output prior to the code changes
- The automated EnKF tests pass